### PR TITLE
groups and calls have optional avatar

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -483,6 +483,7 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
         NSMutableAttributedString *attributedText = [[NSMutableAttributedString alloc] initWithString:allText
                                                                                            attributes:attrs];
         if([call date]!=nil) {
+            // Not a group meta message
             NSDictionary *subAttrs = [NSDictionary dictionaryWithObjectsAndKeys:
                                   regularFont, NSFontAttributeName, nil];
             const NSRange range = NSMakeRange([text length],[[call dateText] length]);
@@ -495,7 +496,10 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
             } else {
                 callCell.incomingCallImageView.image = [call thumbnailImage];
             }
-
+        }
+        else {
+            // A group meta message
+            callCell.incomingCallImageView.image = [call thumbnailImage];
         }
         
         callCell.cellLabel.attributedText = attributedText;

--- a/JSQMessagesViewController/Model/JSQCall.h
+++ b/JSQMessagesViewController/Model/JSQCall.h
@@ -13,7 +13,11 @@ typedef enum : NSUInteger {
     kCallOutgoing = 1,
     kCallIncoming = 2,
     kCallMissed   = 3,
+    kGroupUpdateJoin = 4,
+    kGroupUpdateLeft = 5,
+    kGroupUpdate = 6
 } CallStatus;
+
 
 
 @interface JSQCall : NSObject <JSQMessageData, NSCoding, NSCopying>
@@ -44,6 +48,11 @@ typedef enum : NSUInteger {
  * Returns message type for adapter
  */
 @property (nonatomic) TSMessageAdapterType messageType;
+
+/*
+ * User can configure whether a thumbnail is used in the display of this cell or not
+ */
+@property (nonatomic) BOOL useThumbnail;
 
 
 #pragma mark - Initialization 

--- a/JSQMessagesViewController/Model/JSQCall.m
+++ b/JSQMessagesViewController/Model/JSQCall.m
@@ -73,10 +73,34 @@
     return [dateFormatter stringFromDate:_date];
 }
 
--(UIImage*)thumbnailImage
-{
-    return nil;
+-(UIImage*)thumbnailImage {
+    // This relies on those assets being in the project
+    if(!_useThumbnail) {
+        return nil;
+    }
+    switch (_status) {
+        case kCallOutgoing:
+            return [UIImage imageNamed:@"statCallOutgoing--blue"];
+            break;
+        case kCallIncoming:
+        case kCallMissed:
+            return [UIImage imageNamed:@"statCallIncoming--blue"];
+            break;
+        case kGroupUpdate:
+            return [UIImage imageNamed:@"statRefreshedGroup--blue"];
+            break;
+        case kGroupUpdateLeft:
+            return [UIImage imageNamed:@"statLeftGroup--blue"];
+            break;
+        case kGroupUpdateJoin:
+            return [UIImage imageNamed:@"statJoinedGroup--blue"];
+            break;
+        default:
+            return nil;
+            break;
+    }
 }
+
 
 #pragma mark - NSObject
 


### PR DESCRIPTION
.consumer must specify that it should be used and provide images in project of naming convention. otherwise no image will be used
