### PR TITLE
If a key is missing from localization, fall back on base l10n

### DIFF
--- a/JSQMessagesViewController/Categories/NSBundle+JSQMessages.m
+++ b/JSQMessagesViewController/Categories/NSBundle+JSQMessages.m
@@ -36,7 +36,19 @@
 
 + (NSString *)jsq_localizedStringForKey:(NSString *)key
 {
-    return NSLocalizedStringFromTableInBundle(key, @"JSQMessages", [NSBundle jsq_messagesAssetBundle], nil);
+    NSString *value = NSLocalizedStringFromTableInBundle(key, @"JSQMessages", [NSBundle jsq_messagesAssetBundle], nil);
+    
+    if ([value isEqualToString:key]) {
+        // This translation is partial, and the key we're looking up is missing
+        // Fall back to the Base localization
+        if (![[[NSLocale preferredLanguages] objectAtIndex:0] isEqualToString:@"en"]) {
+            NSString *baseTranslationPath = [[NSBundle jsq_messagesAssetBundle] pathForResource:@"Base" ofType:@"lproj"];
+            NSBundle *baseTranslationBundle = [NSBundle bundleWithPath:baseTranslationPath];
+            value = [baseTranslationBundle localizedStringForKey:key value:@"" table:@"JSQMessages"];
+        }
+    }
+    
+    return value;
 }
 
 @end


### PR DESCRIPTION
Fixes [Signal-iOS #1437](https://github.com/WhisperSystems/Signal-iOS/issues/1437). In some localizations, such as Italian, VoiceOver reads an accessibility key lookup string instead of the sender and message of a chat bubble. This patch fixes it by falling back on the Base localization if a translation has some, but not all, of the localization strings.