### PR TITLE
Add Croatian localization

### DIFF
--- a/JSQMessagesViewController/Assets/JSQMessagesAssets.bundle/hr.lproj/JSQMessages.strings
+++ b/JSQMessagesViewController/Assets/JSQMessagesAssets.bundle/hr.lproj/JSQMessages.strings
@@ -1,0 +1,29 @@
+//
+//  Created by Jesse Squires
+//  http://www.jessesquires.com
+//
+//
+//  Documentation
+//  http://cocoadocs.org/docsets/JSQMessagesViewController
+//
+//
+//  GitHub
+//  https://github.com/jessesquires/JSQMessagesViewController
+//
+//
+//  License
+//  Copyright (c) 2014 Jesse Squires
+//  Released under an MIT license: http://opensource.org/licenses/MIT
+//
+
+//  ********************************
+//  Special thanks to the localization contributors!
+//
+//  https://github.com/jessesquires/JSQMessagesViewController/issues/237
+//  ********************************
+
+"load_earlier_messages" = "Učitaj ranije poruke";
+
+"send" = "Šalji";
+
+"new_message" = "Nova poruka";


### PR DESCRIPTION
#### Fixes: <a href="https://github.com/WhisperSystems/Signal-iOS/issues/1493">Signal-iOS #1493</a> localization for input form and submit text (button)
Keys: SEND_BUTTON_TITLE, MESSAGE_COMPOSEVIEW_TITLE

@michaelkirk please merge this, it's really irritating to see the English words instead of Croatian.
