### PR TITLE
remove unnecessary keyboard unassignment

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesKeyboardController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesKeyboardController.m
@@ -130,7 +130,9 @@ typedef void (^JSQAnimationCompletionBlock)(BOOL finished);
     [self jsq_unregisterForNotifications];
 
     [self jsq_setKeyboardViewHidden:NO];
-    self.keyboardView = nil;
+    // No need to set keyboardView to nil here
+    // Plus we need it for future "dismiss keyboard" gesture recognition.
+    // self.keyboardView = nil;
 }
 
 #pragma mark - Notifications


### PR DESCRIPTION
Backstory is that in Signal we want to toggle the default keyboard.

To do this we dismiss and then pop the keyboard.

However, the event listeners cause an unsightly bounce animation when
this happens, so we'd temporarily disable the event listeners.

But then there is this side effect of unassigned the keyboard view when
toggling off the event listeners. There seems to be no reason for it.
(famous last words).

The consequence of unassigning the keyboard view was that future
calculations about keyboard dismissal were wrong, preventing you from
being able to dismiss the keyboard after sending a message.

PTAL @charlesmchen 