### PR TITLE
Use Signal localizations.

### DIFF
--- a/JSQMessagesViewController/Categories/NSBundle+JSQMessages.m
+++ b/JSQMessagesViewController/Categories/NSBundle+JSQMessages.m
@@ -36,7 +36,9 @@
 
 + (NSString *)jsq_localizedStringForKey:(NSString *)key
 {
-    return NSLocalizedStringFromTableInBundle(key, @"JSQMessages", [NSBundle jsq_messagesAssetBundle], nil);
+    // In Signal, we prefer to use our own translations to the incomplete translations in this bundle
+    // return NSLocalizedStringFromTableInBundle(key, @"JSQMessages", [NSBundle jsq_messagesAssetBundle], nil);
+    return NSLocalizedString(key, nil);
 }
 
 @end


### PR DESCRIPTION
The JSQMessagesViewController translations are incomplete, and it's much
simpler for our translators to translate in one place.

PTAL @charlesmchen 